### PR TITLE
Include labels on resolver timing

### DIFF
--- a/prometheus/prometheus.go
+++ b/prometheus/prometheus.go
@@ -57,7 +57,7 @@ func Register() {
 		Name:    "graphql_resolver_duration_ms",
 		Help:    "The time taken to resolve a field by graphql server.",
 		Buckets: prometheusclient.ExponentialBuckets(1, 2, 11),
-	}, []string{"exitStatus"})
+	}, []string{"exitStatus", "object", "field"})
 
 	timeToHandleRequest = prometheusclient.NewHistogramVec(prometheusclient.HistogramOpts{
 		Name:    "graphql_request_duration_ms",
@@ -101,7 +101,7 @@ func ResolverMiddleware() graphql.FieldMiddleware {
 			exitStatus = exitStatusSuccess
 		}
 
-		timeToResolveField.With(prometheusclient.Labels{"exitStatus": exitStatus}).
+		timeToResolveField.WithLabelValues(exitStatus, rctx.Object, rctx.Field.Name).
 			Observe(float64(time.Since(observerStart).Nanoseconds() / int64(time.Millisecond)))
 
 		resolverCompletedCounter.WithLabelValues(rctx.Object, rctx.Field.Name).Inc()


### PR DESCRIPTION
Given that the counters are labeled with object label and field it's super useful to label the timing as well because otherwise, it's impossible to see which resolvers are taking up too much time.