### PR TITLE
Fix span hierarchy (operation and fields) and add field error management

### DIFF
--- a/gqlopentracing/tracer.go
+++ b/gqlopentracing/tracer.go
@@ -11,7 +11,13 @@ import (
 )
 
 type (
-	Tracer struct{}
+	Tracer struct {
+		OperationName string
+	}
+)
+
+const (
+	DefaultOperationName = "graphql"
 )
 
 var _ interface {
@@ -30,7 +36,14 @@ func (a Tracer) Validate(schema graphql.ExecutableSchema) error {
 
 func (a Tracer) InterceptOperation(ctx context.Context, next graphql.OperationHandler) graphql.ResponseHandler {
 	oc := graphql.GetOperationContext(ctx)
-	span, ctx := opentracing.StartSpanFromContext(ctx, "graphql")
+
+	// Get operation name
+	operationName := a.OperationName
+	if operationName == "" {
+		operationName = DefaultOperationName
+	}
+
+	span, ctx := opentracing.StartSpanFromContext(ctx, operationName)
 	ext.SpanKind.Set(span, "server")
 	ext.Component.Set(span, "gqlgen")
 

--- a/gqlopentracing/tracer.go
+++ b/gqlopentracing/tracer.go
@@ -51,6 +51,15 @@ func (a Tracer) InterceptField(ctx context.Context, next graphql.Resolver) (inte
 
 	res, err := next(ctx)
 
+	if err != nil {
+		ext.Error.Set(span, true)
+		span.LogFields(
+			log.String("event", "error"),
+			log.String("error.message", err.Error()),
+			log.String("error.kind", fmt.Sprintf("%T", err)),
+		)
+	}
+
 	errList := graphql.GetFieldErrors(ctx, fc)
 	if len(errList) != 0 {
 		ext.Error.Set(span, true)


### PR DESCRIPTION
# Description

That pull request propose a fix and a new feature.

# Feature

- Add support for catching field error and add it to the span with error flag
- Add support for gormmigrate in a dedicated business package
- Add support to disable tracing for fields with no resolver

# Fix

- Fix span hierarchy to not have all fields starting at the same time. Here is the result:
![Jaeger-UI](https://user-images.githubusercontent.com/2989735/130140098-cf574433-d0c4-46ac-a7b7-72379b6bbde2.png)

Tell me there is anything to change.
